### PR TITLE
Enable injection from SwiftUI views.

### DIFF
--- a/Sources/Inject/Integrations/SwiftUI.swift
+++ b/Sources/Inject/Integrations/SwiftUI.swift
@@ -4,6 +4,8 @@ import SwiftUI
 #if DEBUG
 public extension SwiftUI.View {
     func enableInjection() -> some SwiftUI.View {
+        _ = Inject.load
+        
         // Use AnyView in case the underlying view structure changes during injection.
         // This is only in effect in debug builds.
         return AnyView(self)


### PR DESCRIPTION
In a SwiftUI only app, InjectionIII was never connected.

Not sure if there is a better place to put this?