### PR TITLE
Suggested simplified SwiftUI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ You can either add `import Inject` in individual files in your project or use
 #### **SwiftUI**
 Just 2 steps to enable injection in your `SwiftUI` Views
 
-- Add `@ObservedObject private var iO = Inject.observer` variable
 - call `.enableInjection()` at the end of your body definition
+- add `@ObserveInjection var inject` to your view struct
 
 > *Remember you **don't need** to remove this code when you are done, it's NO-OP in production builds.*
 

--- a/Sources/Inject/Integrations/SwiftUI.swift
+++ b/Sources/Inject/Integrations/SwiftUI.swift
@@ -5,11 +5,12 @@ import SwiftUI
 public extension SwiftUI.View {
     func enableInjection() -> some SwiftUI.View {
         _ = Inject.load
+        
         // Use AnyView in case the underlying view structure changes during injection.
         // This is only in effect in debug builds.
         return AnyView(self)
     }
-    
+
     func onInjection(callback: @escaping (Self) -> Void) -> some SwiftUI.View {
         onReceive(Inject.observer.objectWillChange, perform: {
             callback(self)

--- a/Sources/Inject/Integrations/SwiftUI.swift
+++ b/Sources/Inject/Integrations/SwiftUI.swift
@@ -4,13 +4,9 @@ import SwiftUI
 #if DEBUG
 public extension SwiftUI.View {
     func enableInjection() -> some SwiftUI.View {
-        _ = Inject.load
-        
-        // Use AnyView in case the underlying view structure changes during injection.
-        // This is only in effect in debug builds.
-        return AnyView(self)
+        AnyView(self)
     }
-
+    
     func onInjection(callback: @escaping (Self) -> Void) -> some SwiftUI.View {
         onReceive(Inject.observer.objectWillChange, perform: {
             callback(self)
@@ -19,14 +15,29 @@ public extension SwiftUI.View {
     }
 }
 
+@propertyWrapper
+public struct ObserveInjection: DynamicProperty {
+    @ObservedObject private var iO = Inject.observer
+    public init() {
+        _ = Inject.load
+    }
+    public private(set) var wrappedValue: Inject.Type = Inject.self
+}
+
 #else
 public extension SwiftUI.View {
     @inlinable @inline(__always)
     func enableInjection() -> Self { self }
 
     @inlinable @inline(__always)
-    func onInjection(callback: @escaping (Self) -> Void) -> some SwiftUI.View {
+    func onInjection(callback: @escaping (Self) -> Void) -> Self {
         self
     }
+}
+
+@propertyWrapper
+public struct ObserveInjection {
+    public init() {}
+    public private(set) var wrappedValue: Inject.Type = Inject.self
 }
 #endif

--- a/Sources/Inject/Integrations/SwiftUI.swift
+++ b/Sources/Inject/Integrations/SwiftUI.swift
@@ -4,7 +4,10 @@ import SwiftUI
 #if DEBUG
 public extension SwiftUI.View {
     func enableInjection() -> some SwiftUI.View {
-        AnyView(self)
+        _ = Inject.load
+        // Use AnyView in case the underlying view structure changes during injection.
+        // This is only in effect in debug builds.
+        return AnyView(self)
     }
     
     func onInjection(callback: @escaping (Self) -> Void) -> some SwiftUI.View {
@@ -18,9 +21,7 @@ public extension SwiftUI.View {
 @propertyWrapper
 public struct ObserveInjection: DynamicProperty {
     @ObservedObject private var iO = Inject.observer
-    public init() {
-        _ = Inject.load
-    }
+    public init() {}
     public private(set) var wrappedValue: Inject.Type = Inject.self
 }
 


### PR DESCRIPTION
I've enjoyed the fast iteration afforded by this library, thanks for putting it together!

In the attached pull request is my suggestion for a slightly simpler SwiftUI integration. 
1) Replaces adding `@ObservedObject private var iO = Inject.observer` with `@Injection var inject`.
2) Move callback config into `enableInjection` function

Not sure if everyone would agree on this approach, but feels a little cleaner and also allows stripping the 'ObservedObject' component from release builds.