### PR TITLE
Add .watchOS(.v6) as a supported platform to stop Xcode from thinking all WatchOS versions are supported

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
     platforms: [
             .macOS(.v10_15),
             .iOS(.v13),
-            .tvOS(.v13)
+            .tvOS(.v13),
+            .watchOS(.v6)
         ],
     products: [
         .library(


### PR DESCRIPTION
See https://github.com/krzysztofzablocki/Inject/issues/22