### PR TITLE
Forward largeTitleDisplayMode to host

### DIFF
--- a/Sources/Inject/Integrations/Hosts.swift
+++ b/Sources/Inject/Integrations/Hosts.swift
@@ -68,6 +68,7 @@ public class _InjectableViewControllerHost<Hosted: InjectViewControllerType>: In
         navigationItem.backBarButtonItem = instance.navigationItem.backBarButtonItem
         navigationItem.leftBarButtonItems = instance.navigationItem.leftBarButtonItems
         navigationItem.rightBarButtonItems = instance.navigationItem.rightBarButtonItems
+        navigationItem.largeTitleDisplayMode = instance.navigationItem.largeTitleDisplayMode
         #endif
 #endif
         


### PR DESCRIPTION
For now, if the view controller child sets `largeTitleDisplayMode` to `false`, the container does not replicate this setting.
This commit fixes this behavior.