### PR TITLE
Copy tabBarItem when embedded in TabBarController

### DIFF
--- a/Sources/Inject/Integrations/Hosts.swift
+++ b/Sources/Inject/Integrations/Hosts.swift
@@ -62,6 +62,7 @@ public class _InjectableViewControllerHost<Hosted: InjectViewControllerType>: In
         instance.didMove(toParent: self)
         
         title = instance.title
+        tabBarItem = instance.tabBarItem
         #if !os(tvOS)
         navigationItem.titleView = instance.navigationItem.titleView
         navigationItem.backButtonTitle = instance.navigationItem.backButtonTitle


### PR DESCRIPTION
### Description

When `ViewControllerHost` is added to a `UITabBarController` its tabBarItem is missing/no icon is shown in the TabBar.

### Tasks

- [x] Copy tabBarItem on reload

### Infos for Reviewer

Here is my setup. I changed line 3 and added `Inject.ViewControllerHost(...)` which resulted in a missing tabBarItem (first image).

```swift
let tabBarController = UITabBarController()

let homeVC = Inject.ViewControllerHost(HomeViewController(app: self.app, dependencies: self.dependencies))
let homeNavigationVC = UINavigationController(rootViewController: homeVC)
homeNavigationVC.navigationBar.prefersLargeTitles = true

tabBarController.viewControllers = [homeNavigationVC, ...]
```

After my changes the tabBarItem correctly appears (2nd Image).

![Result](https://user-images.githubusercontent.com/18739004/166097154-d2742c84-e0ed-4889-90e2-ab6e5b689893.png)

