### PR TITLE
Set deployment target to iOS 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Inject",
     platforms: [
             .macOS(.v10_15),
-            .iOS(.v13),
+            .iOS(.v11),
             .tvOS(.v13)
         ],
     products: [

--- a/Sources/Inject/Inject.swift
+++ b/Sources/Inject/Inject.swift
@@ -13,8 +13,10 @@ public protocol InjectListener {
 
 /// Public namespace for using Inject API
 public enum Inject {
+    @available(iOS 13.0, *)
     public static let observer = injectionObserver
     public static let load: Void = loadInjectionImplementation
+    @available(iOS 13.0, *)
     public static var animation: SwiftUI.Animation?
 }
 
@@ -43,6 +45,7 @@ private var loadInjectionImplementation: Void = {
     Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/" + bundleName)?.load()
 }()
 
+@available(iOS 13.0, *)
 public class InjectionObserver: ObservableObject {
     @Published public private(set) var injectionNumber = 0
     private var cancellable: AnyCancellable?
@@ -61,11 +64,16 @@ public class InjectionObserver: ObservableObject {
     }
 }
 
+@available(iOS 13.0, *)
 private let injectionObserver = InjectionObserver()
+@available(iOS 13.0, *)
 private var injectionObservationKey = arc4random()
 
 public extension InjectListener where Self: NSObject {
     func onInjection(callback: @escaping (Self) -> Void) {
+        guard #available(iOS 13.0, *) else {
+            return
+        }
         let observation = injectionObserver.objectWillChange.sink(receiveValue: { [weak self] in
             guard let self = self else { return }
             callback(self)
@@ -76,7 +84,9 @@ public extension InjectListener where Self: NSObject {
 }
 
 #else
+@available(iOS 13.0, *)
 public class InjectionObserver: ObservableObject {}
+@available(iOS 13.0, *)
 private let injectionObserver = InjectionObserver()
 private var loadInjectionImplementation: Void = {}()
 

--- a/Sources/Inject/Integrations/SwiftUI.swift
+++ b/Sources/Inject/Integrations/SwiftUI.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 
 #if DEBUG
+@available(iOS 13.0, *)
 public extension SwiftUI.View {
     func enableInjection() -> some SwiftUI.View {
         _ = Inject.load
@@ -19,6 +20,7 @@ public extension SwiftUI.View {
     }
 }
 
+@available(iOS 13.0, *)
 @propertyWrapper
 public struct ObserveInjection: DynamicProperty {
     @ObservedObject private var iO = Inject.observer
@@ -27,6 +29,7 @@ public struct ObserveInjection: DynamicProperty {
 }
 
 #else
+@available(iOS 13.0, *)
 public extension SwiftUI.View {
     @inlinable @inline(__always)
     func enableInjection() -> Self { self }
@@ -37,6 +40,7 @@ public extension SwiftUI.View {
     }
 }
 
+@available(iOS 13.0, *)
 @propertyWrapper
 public struct ObserveInjection {
     public init() {}


### PR DESCRIPTION
### Problem
Our project has deployment target iOS 12. Therefore we can't add `Inject` to our project using SPM.

### Solution
Set minimum required version to iOS 11 (I found that in an earlier commit 63a71761dedc013dc8ce5dd71023231fa9d99943) and add `@available` statements where needed.