### PR TITLE
fix: building failed in release mode

### DIFF
--- a/Sources/Inject/Integrations/Hosts.swift
+++ b/Sources/Inject/Integrations/Hosts.swift
@@ -161,10 +161,10 @@ public class _InjectableViewHost<Hosted: InjectViewType>: InjectViewType {
 #else
 
 extension Inject {
-    public static func ViewControllerHost(_ viewController: InjectViewControllerType) -> InjectViewControllerType {
+    public static func ViewControllerHost<Hosted: InjectViewControllerType>(_ viewController: Hosted) -> Hosted {
         viewController
     }
-    public static func ViewHost(_ view: InjectViewType) -> InjectViewType {
+    public static func ViewHost<Hosted: InjectViewType>(_ view: Hosted) -> Hosted {
         view
     }
 }


### PR DESCRIPTION
code like this may cause an error in release mode:
```
    let viewController = Inject.ViewControllerHost(CustomViewController())
    viewController.xxxProperty = newValue
```

error like this:
```
    value of type 'InjectViewControllerType' (aka 'UIViewController') has no member 'xxxProperty'
```