### PR TITLE
Adds custom injection bundle support

### DIFF
--- a/InjectHotReload.podspec
+++ b/InjectHotReload.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "InjectHotReload"
-  s.version = "1.2.2"
+  s.version = "1.3.0"
   s.summary = "Hot Reloading for Swift applications! "
 
   s.homepage = "https://github.com/krzysztofzablocki/Inject"

--- a/Sources/Inject/Inject.swift
+++ b/Sources/Inject/Inject.swift
@@ -13,6 +13,7 @@ public protocol InjectListener {
 
 /// Public namespace for using Inject API
 public enum Inject {
+    public static var bundlePath = "/Applications/InjectionIII.app/Contents/Resources/"
     @available(iOS 13.0, *)
     public static let observer = injectionObserver
     public static let load: Void = loadInjectionImplementation
@@ -44,10 +45,11 @@ private var loadInjectionImplementation: Void = {
 #endif // OS and environment conditions
 
 #if targetEnvironment(simulator) || os(macOS)
-    if let bundle = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/" + bundleName) {
+
+    if let bundle = Bundle(path: Inject.bundlePath + bundleName) {
         bundle.load()
     } else {
-        print("⚠️ Inject: InjectionIII not found, verify if it's in /Applications")
+        print("⚠️ Inject: InjectionIII bundle not found, verify if it's in \(Inject.bundlePath)")
     }
 #endif
 }()


### PR DESCRIPTION
This MR adds customization support for injection bundles. 

Reading [InjectionIII](https://github.com/johnno1962/InjectionIII) documentation, we read in [Variations on using the InjectionIII app](https://github.com/johnno1962/InjectionIII#variations-on-using-the-injectioniii-app) section:

> Standalone Injection: Since 4.4.*+ this is now the recommended way of using injection as it contains fewer moving parts that need to be in place for injection to "just work".  (...) download a [binary release](https://github.com/johnno1962/InjectionIII/releases) of the app to make available the "iOSInjection.bundle" but no longer need to run the app (though it still works as it did before if you do).

Thinking about this, and trying to find ways to decrease the number of things my colleagues need to do, me and @andredp came up with this solution.
 
This way, we can share the iOS bundle in our project repo, and that way nobody needs to do any additional work to setup Hot Reloading in their machine. For other platforms, this would also works, as long as we keep the bundle names according to list.  

Hopefully this is a good adition to this project. Looking forward to hear from you! :) 