### PR TITLE
Add `os(iOS)` to `childForStatusBarStyle`

### DIFF
--- a/Sources/Inject/Integrations/Hosts.swift
+++ b/Sources/Inject/Integrations/Hosts.swift
@@ -95,7 +95,7 @@ open class _InjectableViewControllerHost<Hosted: InjectViewControllerType>: Inje
         fatalError("init(coder:) has not been implemented")
     }
     
-#if canImport(UIKit)
+#if canImport(UIKit) && os(iOS)
     override open var childForStatusBarStyle: InjectViewControllerType? {
         instance
     }


### PR DESCRIPTION
Don't override `childForStatusBarStyle` on tvOS because the property is not available.

https://developer.apple.com/documentation/uikit/uiviewcontroller/1621433-childforstatusbarstyle