### PR TITLE
Xcode 15.2+xrOS

### DIFF
--- a/Sources/Inject/Inject.swift
+++ b/Sources/Inject/Inject.swift
@@ -36,6 +36,8 @@ private var loadInjectionImplementation: Void = {
     let bundleName = "macOSInjection.bundle"
 #elseif os(tvOS)
     let bundleName = "tvOSInjection.bundle"
+#elseif os(xrOS)
+    let bundleName = "xrOSInjection.bundle"
 #elseif targetEnvironment(simulator)
     let bundleName = "iOSInjection.bundle"
 #elseif targetEnvironment(macCatalyst)


### PR DESCRIPTION
Hi, There is a new release candidate 4.8.2 of InjectionIII.app that now contains a xrOSInjection.bundle to solve this new issue with Xcode 15.2 https://github.com/johnno1962/InjectionIII/issues/477. Eventually people will need this code to inject with xrOS. Unfortunately, at the moment it gives a compilation warning.