### PR TITLE
Inject on a device?

### DIFF
--- a/Sources/Inject/Inject.swift
+++ b/Sources/Inject/Inject.swift
@@ -32,6 +32,16 @@ public extension InjectListener {
 #if DEBUG
 private var loadInjectionImplementation: Void = {
     guard objc_getClass("InjectionClient") == nil else { return }
+    // If project has a "Build Phase" running this script, Inject should
+    // work on a device (requires an InjectionIII github release 4.8.0+):
+    // /Applications/InjectionIII.app/Contents/Resources/copy_bundle.sh
+    if let path = Bundle.main.path(forResource:
+            "iOSInjection", ofType: "bundle") ??
+        Bundle.main.path(forResource:
+            "macOSInjection", ofType: "bundle"),
+        Bundle(path: path)?.load() == true {
+        return
+    }
 #if os(macOS)
     let bundleName = "macOSInjection.bundle"
 #elseif os(tvOS)


### PR DESCRIPTION
Recently, sparked by [this issue](https://github.com/johnno1962/InjectionIII/issues/463#event-11268490714) using InjectionIII on a device has been made far easier and more reliable. With this change, Inject should also work on a device if people add a build phase and fall back to the old way if they don't.