### PR TITLE
Updates SPM setup snippet since 'package(name:url:from:)' is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,8 @@ Open your project, click on File → Swift Packages → Add Package Dependency�
 ```swift
 dependencies: [
     .package(
-      name: "Inject",
       url: "https://github.com/krzysztofzablocki/Inject.git",
-      from: "1.0.5"
+      from: "1.2.4"
     )
 ]
 ```


### PR DESCRIPTION
The SPM configuration snippet was using the deprecated `package(name:url:from:)`. Updated the README.md to use the recommended `package(url:from:)` and changed `from` to point to the latest version.