### PR TITLE
Workaround for Inject Frameworks (Conditionally Excludes Code in WatchOS)

### DIFF
--- a/Sources/Inject/Inject.swift
+++ b/Sources/Inject/Inject.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import SwiftUI
 
+#if !os(watchOS)
 /// Common protocol interface for classes that support observing injection events
 /// This is automatically added to all NSObject subclasses like `ViewController`s or `Window`s
 public protocol InjectListener {
@@ -116,3 +117,4 @@ public extension InjectListener where Self: NSObject {
     func onInjection(callback: @escaping (Self) -> Void) {}
 }
 #endif // DEBUG
+#endif

--- a/Sources/Inject/Integrations/Hosts.swift
+++ b/Sources/Inject/Integrations/Hosts.swift
@@ -1,3 +1,4 @@
+#if !os(watchOS)
 #if canImport(UIKit)
 import UIKit
 public typealias InjectViewControllerType = UIViewController
@@ -179,4 +180,5 @@ extension Inject {
     }
 }
 
+#endif
 #endif

--- a/Sources/Inject/Integrations/KitFrameworks.swift
+++ b/Sources/Inject/Integrations/KitFrameworks.swift
@@ -1,3 +1,4 @@
+#if !os(watchOS)
 #if canImport(UIKit)
 import Foundation
 import UIKit
@@ -11,4 +12,5 @@ import Foundation
 extension NSView: InjectListener {}
 extension NSViewController: InjectListener {}
 extension NSWindow: InjectListener {}
+#endif
 #endif

--- a/Sources/Inject/Integrations/SwiftUI.swift
+++ b/Sources/Inject/Integrations/SwiftUI.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 
+#if !os(watchOS)
 #if DEBUG
 @available(iOS 13.0, *)
 public extension SwiftUI.View {
@@ -46,4 +47,5 @@ public struct ObserveInjection {
     public init() {}
     public private(set) var wrappedValue: Inject.Type = Inject.self
 }
+#endif
 #endif


### PR DESCRIPTION
### Description:

This temporary workaround allows shared frameworks using Inject to compile for WatchOS by excluding code within conditional blocks when the target platform is watchOS.

### Important Note:

This is a limited solution that only addresses code compilation issues. It doesn't guarantee full framework functionality in watchOS environments. Explore alternative approaches for complete watchOS compatibility.

### Future Work:

- Investigate a permanent solution for using Inject frameworks on WatchOS.
