### PR TITLE
Work around String metatype bug

### DIFF
--- a/Sources/Inject/Integrations/SwiftUI.swift
+++ b/Sources/Inject/Integrations/SwiftUI.swift
@@ -26,7 +26,8 @@ public extension SwiftUI.View {
 public struct ObserveInjection: DynamicProperty {
     @ObservedObject private var iO = InjectConfiguration.observer
     public init() {}
-    public private(set) var wrappedValue: InjectConfiguration.Type = InjectConfiguration.self
+    // Use a computed property rather than directly storing the value to work around https://github.com/swiftlang/swift/issues/62003
+    public var wrappedValue: InjectConfiguration.Type { InjectConfiguration.self }
 }
 
 #else
@@ -45,7 +46,8 @@ public extension SwiftUI.View {
 @propertyWrapper @MainActor
 public struct ObserveInjection: DynamicProperty {
     public init() {}
-    public private(set) var wrappedValue: InjectConfiguration.Type = InjectConfiguration.self
+    // Use a computed property rather than directly storing the value to work around https://github.com/swiftlang/swift/issues/62003
+    public var wrappedValue: InjectConfiguration.Type { InjectConfiguration.self }
 }
 #endif
 #endif


### PR DESCRIPTION
There's a bug that causes a crash when attempting to print the description of a type with a stored "thin" metatype: https://github.com/swiftlang/swift/issues/62003

Here's a trivial example that demonstrates the crash and also shows that using a computed works around the issue
```swift
enum E {}

struct Good {
    var e: E.Type { E.self }
}
struct Bad {
    let e: E.Type = E.self
}

print("\(Good())") // prints "Good()"
print("\(Bad())") // crashes
```

Alternatively we could replace the `InjectionConfiguration.Type` property entirely as suggested here: https://github.com/krzysztofzablocki/Inject/pull/20#issuecomment-1102306265