### PR TITLE
.enableInjection() may not have been called.

### DIFF
--- a/Sources/Inject/InjectConfiguration.swift
+++ b/Sources/Inject/InjectConfiguration.swift
@@ -73,6 +73,7 @@ public class InjectionObserver: ObservableObject {
     private var cancellable: AnyCancellable?
 
     fileprivate init() {
+        _ = loadInjectionImplementation
         cancellable = NotificationCenter.default.publisher(for: Notification.Name("INJECTION_BUNDLE_NOTIFICATION"))
             .sink { [weak self] _ in
                 if let animation = InjectConfiguration.animation {


### PR DESCRIPTION
Hey, before too long users will be noticing you no longer need to call ".enableInjection()" for type erasure since Xcode 16. See https://github.com/johnno1962/InjectionIII/pull/526#issuecomment-2493595167. So this PR adds the loading of the injection bundle for the user into the initialiser of the InjectionObserver so it will always be called.