### PR TITLE
HotReload Macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,26 +1,40 @@
-// swift-tools-version:5.3
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "Inject",
     platforms: [
             .macOS(.v10_15),
-            .iOS(.v11),
+            .iOS(.v12),
             .tvOS(.v13)
         ],
     products: [
         .library(
             name: "Inject",
-            targets: ["Inject"]),
+            targets: ["Inject"]
+        ),
     ],
-    
+    traits: [
+        .trait(name: "HotReloadMacro"),
+        .default(enabledTraits: []),
+    ],
     dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "601.0.0"..."602.0.0"),
     ],
     targets: [
         .target(
             name: "Inject",
-            dependencies: []),
+            dependencies: [.targetItem(name: "HotReloadMacro", condition: .when(traits: ["HotReloadMacro"]))]
+        ),
+        .macro(
+            name: "HotReloadMacro",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax", condition: .when(traits: ["HotReloadMacro"])),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax", condition: .when(traits: ["HotReloadMacro"]))
+            ],
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
     targets: [
         .target(
             name: "Inject",
-            dependencies: [.targetItem(name: "HotReloadMacro", condition: .when(traits: ["HotReloadMacro"]))]
+            dependencies: [.targetItem(name: "HotReloadMacro", condition: .when(traits: ["HotReloadMacro"]))],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .macro(
             name: "HotReloadMacro",

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Inject",
+    platforms: [
+            .macOS(.v10_15),
+            .iOS(.v11),
+            .tvOS(.v13)
+        ],
+    products: [
+        .library(
+            name: "Inject",
+            targets: ["Inject"]),
+    ],
+    
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "Inject",
+            dependencies: []),
+    ]
+)

--- a/Sources/HotReloadMacro/HotReloadMacro.swift
+++ b/Sources/HotReloadMacro/HotReloadMacro.swift
@@ -110,6 +110,7 @@ public struct HotReloadMacro: MemberMacro {
             
             @_implements(View, body)
             @_disfavoredOverload
+            @ViewBuilder
             \(accessControl)var __body: AnyView {
                 AnyView(body)
             }

--- a/Sources/HotReloadMacro/HotReloadMacro.swift
+++ b/Sources/HotReloadMacro/HotReloadMacro.swift
@@ -1,0 +1,129 @@
+//
+//  HotReloadMacro.swift
+//  Inject
+//
+//  Created by Wouter Hennen on 23/12/2025.
+//
+
+#if HotReloadMacro
+
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import Foundation
+
+extension TokenKind {
+    var isVisibilityKeyword: Bool {
+        switch self {
+        case .keyword(.public),
+             .keyword(.private),
+             .keyword(.fileprivate),
+             .keyword(.internal),
+             .keyword(.package),
+             .keyword(.open):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+public struct HotReloadMacro: MemberMacro {
+    
+    static func isViewType(_ type: TypeSyntax) -> Bool {
+        if let identifier = type.as(IdentifierTypeSyntax.self) {
+            return identifier.name.text == "View"
+        }
+
+        if let member = type.as(MemberTypeSyntax.self) {
+            return member.name.text == "View"
+                && member.baseType.description.trimmingCharacters(in: .whitespacesAndNewlines) == "SwiftUI"
+        }
+
+        return false
+    }
+    
+    static func hasBodyProperty(_ structDecl: StructDeclSyntax) -> Bool {
+        structDecl.memberBlock.members.contains { member in
+            guard let varDecl = member.decl.as(VariableDeclSyntax.self) else {
+                return false
+            }
+
+            return varDecl.bindings.contains { binding in
+                guard
+                    let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+                    identifier.identifier.text == "body",
+                    let typeAnnotation = binding.typeAnnotation,
+                    let someType = typeAnnotation.type.as(SomeOrAnyTypeSyntax.self),
+                    someType.someOrAnySpecifier.tokenKind == .keyword(.some)
+                else {
+                    return false
+                }
+
+                return isViewType(someType.constraint)
+            }
+        }
+    }
+    
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        
+        // Not stricly necessary, mostly to prevent misuse of macro
+        // A View can technically be an enum, but we cannot support that case as we cannot add the `ObserveInjection` property wrapper.
+        guard let declaration = declaration.as(StructDeclSyntax.self) else {
+            context.diagnose(.init(node: declaration, message: MacroExpansionErrorMessage("HotReload macro must be attached to a struct")))
+            return []
+        }
+        
+        // Not stricly necessary, mostly to prevent misuse of macro
+        // Will cause false positive when the View conformance is declared in an extension.
+        guard declaration.inheritanceClause?.inheritedTypes.lazy.map(\.type).contains(where: isViewType) == true else {
+            context.diagnose(.init(node: declaration, message: MacroExpansionErrorMessage("\(declaration.name) must conform to the View protocol")))
+            return []
+        }
+        
+        // Prevents applying macro before a view body is declared
+        // This fixes two issues:
+        //  - The macro overriding the Body typealias, which causes autocomplete to fill in `var body: AnyView`
+        //  - The macro providing a valid `body` implementation, but no existing declaration is present.
+        //      This will compile, but will cause an infinite loop.
+        guard hasBodyProperty(declaration) else {
+            context.diagnose(.init(node: declaration, message: MacroExpansionErrorMessage("\(declaration.name) must have a view body")))
+            return []
+        }
+        
+        var accessControl = declaration.modifiers.first(where: { $0.name.tokenKind.isVisibilityKeyword })?.name.trimmed
+        accessControl?.trailingTrivia = .space
+        
+        return [
+            """
+            #if DEBUG
+            
+            @ObserveInjection private var __observeInjection
+            
+            \(accessControl)typealias Body = AnyView
+            
+            @_implements(View, body)
+            @_disfavoredOverload
+            \(accessControl)var __body: AnyView {
+                AnyView(body)
+            }
+            #endif
+            """
+        ]
+    }
+}
+
+@main
+struct MyMacroPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        HotReloadMacro.self,
+    ]
+}
+
+#endif

--- a/Sources/Inject/HotReload.swift
+++ b/Sources/Inject/HotReload.swift
@@ -1,0 +1,15 @@
+//
+//  HotReload.swift
+//  Inject
+//
+//  Created by Wouter Hennen on 23/12/2025.
+//
+
+#if !os(watchOS)
+#if HotReloadMacro
+
+@attached(member, names: named(__observeInjection), named(Body), named(__body))
+public macro HotReload() = #externalMacro(module: "HotReloadMacro", type: "HotReloadMacro")
+
+#endif
+#endif


### PR DESCRIPTION
Hey there! I'm a happy user of this library, but always needing to add `@ObserveInjection` and `.enableInjection()` felt a bit repetitive. I wrote a small macro which does this for you, which reduces the boilerplate even more.

With this macro, you're able to write

```swift
@HotReload
struct ExampleView: View {
    var body: some View {
        Text("Hello world!")
    }
}
```

Instead of:
```swift
struct ExampleView: View {
    
    @ObserveInjection var observe
    
    var body: some View {
        Text("Hello world!")
            .enableInjection()
    }
}
```

### Macro details
After macro expansion, the struct will look like this:

```swift
struct ExampleView: View {
    var body: some View {
        Text("Hello world!")
    }

#if DEBUG

@ObserveInjection private var __observeInjection

typealias Body = AnyView

@_implements(View, body)
@_disfavoredOverload
var __body: AnyView {
    AnyView(body)
}
#endif
}
```

**Some notes**
- `__body` acts as a replacement for the existing `body` implementation. Essentially, we have two `body` implementations. `__body` will be picked instead of `body`, as its type matches the `Body` type which we explicitly set to `AnyView`. The macro enforces that the `body` type cannot be `AnyView`, as that would cause conflicts.
- `@_disfavoredOverload` is added, so `body` has preference over `__body` when used inside `__body`. Confusing but without it it'll pick `__body` and cause infinite loops :)
- `_ = InjectConfiguration.load` isn't called in the body, because it should already be loaded in by `ObserveInjection`
- The generated code is wrapped in `#if DEBUG` so it's excluded from production builds

**Other things worth mentioning**
- As macros _can_ be slow in some setups, the macro is disabled by default, and can be enabled with the `HotReloadMacro` package trait. If it's not specified, swift-syntax won't be resolved and compiled. I'm not sure if Xcode supports specifying traits yet, so not sure what the best default would be.
In a swift package, the macro can be enabled by specifying the trait in the dependency.
`.package(url: "https://github.com/Wouter01/Inject", branch: "main", traits: ["HotReloadMacro"])`

- The `package.swift` minimum swift version has been bumped to 6.1 to support macros and traits. A `package@swift-5.3.swift` file has been added which _should_ still support earlier swift versions, although I did not test this.
- There's a bunch of swift concurrency errors because of bumping the tools version to 6.1. As they are unrelated to this PR, I've disabled them by setting the swift language mode back to v5.

If you have any suggestions or concerns let me know!